### PR TITLE
Depend basicstation gateway bridge on mosquitto

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - INTEGRATION__MQTT__EVENT_TOPIC_TEMPLATE=eu868/gateway/{{ .GatewayID }}/event/{{ .EventType }}
       - INTEGRATION__MQTT__STATE_TOPIC_TEMPLATE=eu868/gateway/{{ .GatewayID }}/state/{{ .StateType }}
       - INTEGRATION__MQTT__COMMAND_TOPIC_TEMPLATE=eu868/gateway/{{ .GatewayID }}/command/#
-    depends_on: 
+    depends_on:
       - mosquitto
   
   chirpstack-gateway-bridge-basicstation:
@@ -41,6 +41,8 @@ services:
       - 3001:3001
     volumes:
       - ./configuration/chirpstack-gateway-bridge:/etc/chirpstack-gateway-bridge
+    depends_on:
+      - mosquitto
 
   chirpstack-rest-api:
     image: chirpstack/chirpstack-rest-api:4


### PR DESCRIPTION
Since the service `chirpstack-gateway-bridge` depends on `mosquitto`, I guess the service `chirpstack-gateway-bridge-basicstation` should depend on `mosquitto` too.

Fixes #91 