### PR TITLE
Fixed region in Gateway Bridge config files

### DIFF
--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_0.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_0.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_1.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_1.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_10.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_10.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_11.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_11.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_2.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_2.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_3.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_3.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_4.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_4.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_5.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_5.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_6.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_6.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_7.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_7.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_8.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_8.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_9.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge-basicstation-cn470_9.toml
@@ -20,7 +20,7 @@ type="basic_station"
   tls_key=""
   ca_cert=""
 
-  region="US915"
+  region="CN470"
   frequency_min=470000000
   frequency_max=510000000
 


### PR DESCRIPTION
Based on LoRaWAN spec, I guess it should be CN470 in cn470 config files instead of US915