### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 import-lorawan-devices:
 	docker-compose run --rm --entrypoint sh --user root chirpstack -c '\
 		apk add --no-cache git && \
-		git clone https://github.com/brocaar/lorawan-devices /tmp/lorawan-devices && \
+		git clone https://github.com/TheThingsNetwork/lorawan-devices /tmp/lorawan-devices && \
 		chirpstack -c /etc/chirpstack import-legacy-lorawan-devices-repository -d /tmp/lorawan-devices'


### PR DESCRIPTION
Update the lorawan-device report to https://github.com/brocaar/lorawan-devices 
The original https://github.com/brocaar/lorawan-devices was not updated since Oct 2022 and is missing a lot of devices.