### PR TITLE
Add a reasonable default Redis persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    command: redis-server --save 300 1 --save 60 100 --appendonly no
     volumes:
       - redisdata:/data
 


### PR DESCRIPTION
Despite the claim of the README.md, `PostgreSQL and Redis data is persisted in Docker volumes`, this is not actually the case. The volume is present, but Redis is not configured to use it.

This question comes up on the forum monthly, if not more frequently. Choose a reasonable default for people to build on.