### PR TITLE
Remove top-level version element

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   chirpstack:
     image: chirpstack/chirpstack:4


### PR DESCRIPTION
The version top-level element is now obosolete:
https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete