### PR TITLE
Updated docs from legacy 'docker-compose' to current 'docker compose'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 import-lorawan-devices:
-	docker-compose run --rm --entrypoint sh --user root chirpstack -c '\
+	docker compose run --rm --entrypoint sh --user root chirpstack -c '\
 		apk add --no-cache git && \
 		git clone https://github.com/brocaar/lorawan-devices /tmp/lorawan-devices && \
 		chirpstack -c /etc/chirpstack import-legacy-lorawan-devices-repository -d /tmp/lorawan-devices'

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ latest revision no longer contains a `LICENSE` file.
 To start the ChirpStack simply run:
 
 ```bash
-$ docker-compose up
+$ docker compose up
 ```
 
 After all the components have been initialized and started, you should be able


### PR DESCRIPTION
Update repo to list current docker cli commands: `docker compose ...`

Refs
- [Docker CLI](https://docs.docker.com/compose/intro/compose-application-model/#cli)
- [Docker V2](https://docs.docker.com/compose/intro/history/#introduction)